### PR TITLE
Output a warning when Phabricator is running on PHP 7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 0.3.1
+## 0.3.2
 
-### Summary
+### Bug Fixes
+
+- Added a warning if the installed PHP version is incompatible with Phabricator.
+
+## 0.3.1
 
 ### Features
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -72,6 +72,12 @@ class phabricator(
     }
   )
 
+  # TODO: It's not currently possible to test for warnings with `rspec-puppet`.
+  # See https://github.com/rodjek/rspec-puppet/issues/108.
+  if $facts['phpversion'] != undef and versioncmp($facts['phpversion'], '7.0.0') >= 0 and versioncmp($facts['phpversion'], '7.1.0') < 0 {
+    warning('Phabricator does not support PHP 7.1. See https://secure.phabricator.com/T12101.')
+  }
+
   include phabricator::config
   include phabricator::install
 }

--- a/spec/acceptance/init_spec.rb
+++ b/spec/acceptance/init_spec.rb
@@ -30,6 +30,20 @@ RSpec.describe 'phabricator' do
     apply_manifest(pp, catch_changes: true)
   end
 
+  # Detect unsupported PHP versions.
+  #
+  # Phabricator doesn't support PHP 7.0, although it _does_ support PHP 7.1
+  # (which implements [async signals](https://wiki.php.net/rfc/async_signals)).
+  # See https://secure.phabricator.com/T9640, https://secure.phabricator.com/T11270
+  # and https://secure.phabricator.com/T12101.
+  #
+  # TODO: If https://secure.phabricator.com/T2383 is resolved then we should be
+  # able to run `./bin/config check` instead.
+  context command('php --version') do
+    its(:exit_status) { is_expected.to be_zero }
+    its(:stdout) { is_expected.not_to start_with('PHP 7.0.'), 'Unsupported PHP version.' }
+  end
+
   describe 'phabricator::config' do
     context group('phabricator') do
       it { is_expected.to exist }


### PR DESCRIPTION
Phabricator doesn't officially support (or, more importantly, function correctly under) PHP 7.0, although it does support PHP 7.1 (which implemented [asynchronous signal handling](https://wiki.php.net/rfc/async_signals)). @jarro2783 pointed out to me yesterday that the acceptance tests were failing locally because `/usr/local/src/phabricator/bin/phd status --local` was exitting with a non-zero exit code. After several hours of debugging, I finally determined that the problem was that the Phabricator Daemons don't function correctly on PHP 7.0.

Basically, prior to PHP 7.0 the following code could be used to enable asynchronous signal handling:

```php
declare(ticks=1);
```

From a [PHP bug report](https://bugs.php.net/bug.php?id=71448):

> Due to an implementation bug, the `declare(ticks=1)` directive leaked into different compilation units prior to PHP 7.0. This is not how `declare()` directives, which are per-file or per-scope, are supposed to work.
>
> Using a single `declare(ticks=1)` in some class inside a multi-class autoloaded project doesn't make a lot of sense. Even on PHP 5.x `declare(ticks=1)` would only affect code that is compiled starting from that declaration, which means that depending on the loading order of classes your whole codebase might end up using ticks or maybe only a few classes that were loaded late. (Not to mention that using ticks will make your code many times slower, but that's a different issue.)
>
> For PHP 7.1 we may make automatic `pcntl` signal handling work without ticks, as we now have a new internal mechanism for handling ordinary timeouts which we can reuse.

Consequently, the Phabricator upstream decided to drop support for PHP 7.0 and to, instead, wait for the implementation of [async signals](https://wiki.php.net/rfc/async_signals#proposed_voting_choices) in PHP 7.1. Some relevant discussions upstream:

  - [Make Phabricator compatible with PHP7](https://secure.phabricator.com/T9640)
  - [PHP 7 does not reasonably support asynchronous signal handling until `async_signals` lands](https://secure.phabricator.com/T11270)
  - [Phabricator PHP 7 Compatibility](https://secure.phabricator.com/T12101)