### PR TITLE
Add support for registering an Almanac device

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.3.3
+
+### Features
+
+- Added support for registering [Almanac devices][almanac].
+
 ## 0.3.2
 
 ### Features
@@ -26,5 +32,6 @@ and starting again from scratch. The rewritten module has comprehensive unit
 tests (with [`rspec-puppet`](http://rspec-puppet.com)) and acceptance tests
 (with [`beaker-rspec`](https://github.com/puppetlabs/beaker-rspec)).
 
+[almanac]: https://secure.phabricator.com/book/phabricator/article/almanac/
 [aphlict]: https://secure.phabricator.com/book/phabricator/article/notifications/
 [phd]: https://secure.phabricator.com/book/phabricator/article/managing_daemons/

--- a/Gemfile
+++ b/Gemfile
@@ -46,4 +46,5 @@ group :system_tests do
   gem 'beaker-puppet_install_helper', require: false
   gem 'beaker-rspec', require: false
   gem 'serverspec', require: false
+  gem 'sshkey', require: false
 end

--- a/manifests/almanac.pp
+++ b/manifests/almanac.pp
@@ -1,0 +1,56 @@
+# Class for registering an Almanac device.
+#
+# @summary This class can be used to register an Almanac device using
+# `./bin/almanac register`. See the
+# {https://secure.phabricator.com/book/phabricator/article/almanac/
+# Almanac User Guide} for further information.
+#
+# @param device The name of the Almanac device to register.
+# @param private_key The contents of an SSH private key that has been associated
+#   with the specified Almanac device. This SSH key must be manually marked as
+#   trusted using the `./bin/almanac trust-key` command.
+#
+class phabricator::almanac(
+  String $device,
+  String $private_key,
+) {
+  $device_id_path   = "${phabricator::install_dir}/phabricator/conf/keys/device.id"
+  $private_key_path = "${phabricator::install_dir}/phabricator/conf/keys/device.key"
+
+  file { 'phabricator/conf/device.key':
+    ensure  => 'file',
+    path    => $private_key_path,
+    content => $private_key,
+    owner   => $phabricator::daemon_user,
+    group   => 'root',
+    mode    => '0400',
+    notify  => Exec['almanac register'],
+    require => Vcsrepo['phabricator'],
+  }
+
+  # TODO: The `strict_indent` check doesn't seem to work properly here. See
+  # https://github.com/relud/puppet-lint-strict_indent-check/issues/11.
+  #
+  # lint:ignore:strict_indent
+  exec { 'almanac register':
+    command => join([
+      "${phabricator::install_dir}/phabricator/bin/almanac register",
+      "--device ${device}",
+      '--force',
+      "--private-key ${private_key_path}",
+    ], ' '),
+    creates => $device_id_path,
+    require => [
+      Class['php::cli'],
+      File['phabricator/conf/local.json'],
+      Php::Extension['mysql'],
+      Vcsrepo['libphutil'],
+      Vcsrepo['phabricator'],
+    ],
+  }
+  # lint:endignore
+
+  if $phabricator::storage_upgrade {
+    Exec['bin/storage upgrade'] -> Exec['almanac register']
+  }
+}

--- a/spec/acceptance/almanac_spec.rb
+++ b/spec/acceptance/almanac_spec.rb
@@ -1,0 +1,57 @@
+require_relative '../spec_helper_acceptance'
+require 'sshkey'
+
+# rubocop:disable Lint/UselessAssignment, RSpec/EmptyExampleGroup
+RSpec.describe 'phabricator::almanac' do
+  key = SSHKey.generate
+
+  # TODO: This is mostly copied from `spec/acceptance/init_spec.rb` and should
+  # be consolidated.
+  pp = <<-EOS
+    include apt
+
+    Apt::Ppa {
+      package_manage => true,
+    }
+
+    # Ensure that `apt-get update` is executed before any packages are
+    # installed. See https://github.com/puppetlabs/puppetlabs-apt/#adding-new-sources-or-ppas.
+    Class['apt::update'] -> Package <| title != 'apt-transport-https' and title != 'ca-certificates' and title != 'software-properties-common' |>
+
+    class { 'php::globals':
+      php_version => '7.1',
+    }
+
+    class { 'php':
+      manage_repos => true,
+      fpm          => false,
+      dev          => false,
+      composer     => false,
+      pear         => false,
+    }
+
+    class { 'phabricator':
+      config_hash => {
+        'mysql.host' => 'localhost',
+        'mysql.user' => 'root',
+        'mysql.pass' => 'root',
+      },
+
+      storage_upgrade          => true,
+      storage_upgrade_user     => 'root',
+      storage_upgrade_password => 'root',
+    }
+
+    include phabricator::daemons
+
+    class { 'phabricator::almanac':
+      device      => 'test',
+      private_key => '#{key.private_key}',
+    }
+  EOS
+
+  # TODO: We can't properly test this class at the moment because there is no
+  # way to create an Almanac device through the CLI or API. As a result,
+  # `Exec['almanac register']` will always fail. See
+  # https://secure.phabricator.com/T12414.
+end

--- a/spec/classes/almanac_spec.rb
+++ b/spec/classes/almanac_spec.rb
@@ -1,0 +1,65 @@
+require_relative '../spec_helper'
+
+RSpec.describe 'phabricator::almanac', type: :class do
+  on_supported_os.each do |os, facts|
+    context "on #{os}" do
+      include_context :module_precondition
+
+      let(:facts) do
+        facts
+      end
+
+      let(:params) do
+        {
+          device: 'test',
+          private_key: 'test',
+        }
+      end
+
+      it { is_expected.to compile.with_all_deps }
+
+      it do
+        is_expected.to contain_file('phabricator/conf/device.key')
+          .with_ensure('file')
+          .with_path('/usr/local/src/phabricator/conf/keys/device.key')
+          .with_content(params[:private_key])
+          .with_owner('phd')
+          .with_group('root')
+          .with_mode('0400')
+          .that_notifies('Exec[almanac register]')
+          .that_requires('Vcsrepo[phabricator]')
+      end
+
+      it do
+        is_expected.to contain_exec('almanac register')
+          .with_command([
+            '/usr/local/src/phabricator/bin/almanac register',
+            "--device #{params[:device]}",
+            '--force',
+            '--private-key /usr/local/src/phabricator/conf/keys/device.key',
+          ].join(' '))
+          .with_creates('/usr/local/src/phabricator/conf/keys/device.id')
+          .that_requires('Class[php::cli]')
+          .that_requires('File[phabricator/conf/local.json]')
+          .that_requires('Php::Extension[mysql]')
+          .that_requires('Vcsrepo[libphutil]')
+          .that_requires('Vcsrepo[phabricator]')
+      end
+
+      context 'when $storage_upgrade is enabled' do
+        let(:module_params) do
+          {
+            storage_upgrade: true,
+            storage_upgrade_user: 'root',
+            storage_upgrade_password: 'password',
+          }
+        end
+
+        it do
+          is_expected.to contain_exec('almanac register')
+            .that_requires('Exec[bin/storage upgrade]')
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Adds support for registering an Almanac device.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/joshuaspence/puppet-phabricator/4)
<!-- Reviewable:end -->
