### PR TITLE
Set `lookup_options`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features
 
 - Added support for registering [Almanac devices][almanac].
+- The `$config_hash` parameter is now deep-merged by default.
 
 ## 0.3.2
 

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -1,4 +1,8 @@
 ---
+lookup_options:
+  phabricator::config_hash:
+    merge:
+      strategy: 'deep'
 phabricator::aphlict::user: 'aphlict'
 phabricator::arcanist_revision: 'stable'
 phabricator::config_hash: {}


### PR DESCRIPTION
Set `lookup_options` to deep merge `phabricator::config_hash`. I based this on examples from http://www.example42.com/2017/04/17/hiera-5/.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/joshuaspence/puppet-phabricator/6)
<!-- Reviewable:end -->
