### PR TITLE
Ensure that Almanac devices are registered before daemons are running

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.3.5
+
+### Bug Fixes
+
+- Ensure that `./bin/almanac register` is executed before the `phd` service is
+  started.
+
 ## 0.3.4
 
 ### Bug Fixes

--- a/manifests/almanac.pp
+++ b/manifests/almanac.pp
@@ -14,6 +14,8 @@ class phabricator::almanac(
   String $device,
   String $private_key,
 ) {
+  include phabricator::daemons
+
   $device_id_path   = "${phabricator::install_dir}/phabricator/conf/keys/device.id"
   $private_key_path = "${phabricator::install_dir}/phabricator/conf/keys/device.key"
 
@@ -40,6 +42,7 @@ class phabricator::almanac(
       "--private-key ${private_key_path}",
     ], ' '),
     creates => $device_id_path,
+    before  => Service['phd'],
     require => [
       Class['php::cli'],
       File['phabricator/conf/local.json'],

--- a/spec/classes/almanac_spec.rb
+++ b/spec/classes/almanac_spec.rb
@@ -39,6 +39,7 @@ RSpec.describe 'phabricator::almanac', type: :class do
             '--private-key /usr/local/src/phabricator/conf/keys/device.key',
           ].join(' '))
           .with_creates('/usr/local/src/phabricator/conf/keys/device.id')
+          .that_comes_before('Service[phd]')
           .that_requires('Class[php::cli]')
           .that_requires('File[phabricator/conf/local.json]')
           .that_requires('Php::Extension[mysql]')


### PR DESCRIPTION
We need to ensure that we register an Almanc device before starting the `phd` service.

```
EXCEPTION: (PhutilProxyException) Error while executing Task ID 28476658. {>} (PhutilAggregateException) Unable to read device public key while attempting to make authenticated method call within the Phabricator cluster. Use `bin/almanac register` to register keys for this device. Exception: File system entity '/usr/local/src/phabricator/conf/keys/device.pub' does not exist.
  - FilesystemException: File system entity '/usr/local/src/phabricator/conf/keys/device.pub' does not exist. at [<phabricator>/src/applications/repository/storage/PhabricatorRepository.php:2062]
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/joshuaspence/puppet-phabricator/7)
<!-- Reviewable:end -->
