### PR TITLE
Don't create the repository directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 ### Breaking Changes
 
 - The default value for `$vcs_user` has been changed from `vcs` to `diffusion`.
+- The repository directory (`/var/repo` by default) is no longer managed by
+  this module. Instead, this directory should be created by
+  `PhabricatorRepositoryPullLocalDaemon`. Consequently, the `$repo_dir`
+  parameter has also been removed.
 
 ### Features
 

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -12,7 +12,6 @@ phabricator::libphutil_revision: 'stable'
 phabricator::logs_dir: '/var/log/phabricator'
 phabricator::phabricator_revision: 'stable'
 phabricator::pid_dir: '/run/phabricator'
-phabricator::repo_dir: '/var/repo'
 phabricator::storage_upgrade: false
 phabricator::storage_upgrade_password: null
 phabricator::storage_upgrade_user: null

--- a/manifests/daemons.pp
+++ b/manifests/daemons.pp
@@ -25,13 +25,6 @@
 class phabricator::daemons(
   Optional[String] $daemon,
 ) {
-  file { $phabricator::repo_dir:
-    ensure => 'directory',
-    owner  => $phabricator::daemon_user,
-    group  => $phabricator::group,
-    mode   => '0755',
-  }
-
   user { $phabricator::daemon_user:
     ensure     => 'present',
     comment    => 'Phabricator Daemons',
@@ -68,7 +61,6 @@ class phabricator::daemons(
       Exec['systemctl-daemon-reload'],
       File[$phabricator::logs_dir],
       File[$phabricator::pid_dir],
-      File[$phabricator::repo_dir],
       Group[$phabricator::group],
       User[$phabricator::daemon_user],
     ],

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -34,7 +34,6 @@
 # @param install_dir
 # @param logs_dir
 # @param pid_dir
-# @param repo_dir
 # @param vcs_user
 #
 class phabricator(
@@ -51,7 +50,6 @@ class phabricator(
   Stdlib::Unixpath $install_dir,
   Stdlib::Unixpath $logs_dir,
   Stdlib::Unixpath $pid_dir,
-  Stdlib::Unixpath $repo_dir,
   String $vcs_user,
 ) {
   if $storage_upgrade {
@@ -68,7 +66,6 @@ class phabricator(
       'phd.log-directory' => $logs_dir,
       'phd.pid-directory' => $pid_dir,
       'phd.user' => $daemon_user,
-      'repository.default-local-path' => $repo_dir,
     }
   )
 

--- a/spec/acceptance/daemons_spec.rb
+++ b/spec/acceptance/daemons_spec.rb
@@ -50,13 +50,6 @@ RSpec.describe 'phabricator::daemons' do
     apply_manifest(pp, catch_changes: true)
   end
 
-  context file('/var/repo') do
-    it { is_expected.to be_directory }
-    it { is_expected.to be_owned_by('phd') }
-    it { is_expected.to be_grouped_into('phabricator') }
-    it { is_expected.to be_mode(755) }
-  end
-
   context user('phd') do
     it { is_expected.to exist }
     it { is_expected.to belong_to_primary_group('phabricator') }

--- a/spec/acceptance/init_spec.rb
+++ b/spec/acceptance/init_spec.rb
@@ -96,7 +96,6 @@ RSpec.describe 'phabricator' do
           'phd.log-directory' => '/var/log/phabricator',
           'phd.pid-directory' => '/run/phabricator',
           'phd.user' => 'phd',
-          'repository.default-local-path' => '/var/repo',
         )
       end
     end

--- a/spec/classes/daemons_spec.rb
+++ b/spec/classes/daemons_spec.rb
@@ -12,14 +12,6 @@ RSpec.describe 'phabricator::daemons', type: :class do
       it { is_expected.to compile.with_all_deps }
 
       it do
-        is_expected.to contain_file('/var/repo')
-          .with_ensure('directory')
-          .with_owner('phd')
-          .with_group('phabricator')
-          .with_mode('0755')
-      end
-
-      it do
         is_expected.to contain_user('phd')
           .with_ensure('present')
           .with_comment('Phabricator Daemons')
@@ -52,7 +44,6 @@ RSpec.describe 'phabricator::daemons', type: :class do
           .that_requires('Exec[systemctl-daemon-reload]')
           .that_requires('File[/var/log/phabricator]')
           .that_requires('File[/run/phabricator]')
-          .that_requires('File[/var/repo]')
           .that_requires('Group[phabricator]')
           .that_requires('User[phd]')
           .that_subscribes_to('Class[php::cli]')

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -53,7 +53,6 @@ RSpec.describe 'phabricator', type: :class do
               'phd.log-directory' => '/var/log/phabricator',
               'phd.pid-directory' => '/run/phabricator',
               'phd.user' => 'phd',
-              'repository.default-local-path' => '/var/repo',
             )
           end
         end
@@ -83,7 +82,6 @@ RSpec.describe 'phabricator', type: :class do
               'phd.log-directory' => '/var/log/phabricator',
               'phd.pid-directory' => '/run/phabricator',
               'phd.user' => 'phd',
-              'repository.default-local-path' => '/var/repo',
             )
           end
         end


### PR DESCRIPTION
There's no need to create the repository directory (`/var/repo`) in Puppet, because the repository-pull daemon will create the directory itself:

```
try {
  $dirname = dirname($local_path);
  if (!Filesystem::pathExists($dirname)) {
    Filesystem::createDirectory($dirname, 0755, $recursive = true);
  }

  if (!Filesystem::pathExists($local_path)) {
    $this->logPull(
      pht(
        'Creating a new working copy for repository "%s".',
        $repository->getDisplayName()));
    if ($is_git) {
      $this->executeGitCreate();
    } else if ($is_hg) {
      $this->executeMercurialCreate();
    } else {
      $this->executeSubversionCreate();
    }
  }

  // ...
}
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/joshuaspence/puppet-phabricator/8)
<!-- Reviewable:end -->
