### PR TITLE
Change default value for VCS user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.3.5 (unreleased)
 
+### Breaking Changes
+
+- The default value for `$vcs_user` has been changed from `vcs` to `diffusion`.
+
 ### Features
 
 - Marked internal classes as private using [`assert_private`](https://github.com/puppetlabs/puppetlabs-stdlib#assert_private).

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -16,7 +16,7 @@ phabricator::repo_dir: '/var/repo'
 phabricator::storage_upgrade: false
 phabricator::storage_upgrade_password: null
 phabricator::storage_upgrade_user: null
-phabricator::vcs_user: 'vcs'
+phabricator::vcs_user: 'diffusion'
 phabricator::aphlict::user: 'aphlict'
 phabricator::daemons::daemon: null
 

--- a/spec/acceptance/init_spec.rb
+++ b/spec/acceptance/init_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe 'phabricator' do
 
       its(:content_as_json) do
         is_expected.to eq(
-          'diffusion.ssh-user' => 'vcs',
+          'diffusion.ssh-user' => 'diffusion',
           'log.access.path' => '/var/log/phabricator/access.log',
           'log.ssh.path' => '/var/log/phabricator/ssh.log',
           'mysql.host' => 'localhost',

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe 'phabricator', type: :class do
         context 'with defaults' do
           it do
             is_expected.to eq(
-              'diffusion.ssh-user' => 'vcs',
+              'diffusion.ssh-user' => 'diffusion',
               'log.access.path' => '/var/log/phabricator/access.log',
               'log.ssh.path' => '/var/log/phabricator/ssh.log',
               'phd.log-directory' => '/var/log/phabricator',
@@ -74,7 +74,7 @@ RSpec.describe 'phabricator', type: :class do
 
           it do
             is_expected.to eq(
-              'diffusion.ssh-user' => 'vcs',
+              'diffusion.ssh-user' => 'diffusion',
               'log.access.path' => '/var/log/phabricator/access.log',
               'log.ssh.path' => '/var/log/phabricator/ssh.log',
               'mysql.host' => config_hash['mysql.host'],


### PR DESCRIPTION
Change the default value for `$vcs_user` from `vcs` to `diffusion`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/joshuaspence/puppet-phabricator/10)
<!-- Reviewable:end -->
