### PR TITLE
Always create the daemon user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 0.4.1 (unreleased)
+
+### Bug Fixes
+
+- The daemon user (`phd`) is now created unconditionally. Previously, this user
+  would only be created if Phabricator daemons were configured on the host. It
+  was discovered that there are other cases in which the daemon user may be
+  required and, as such, it was decided to simply create the daemon user
+  unconditionally.
+
 ## 0.4.0
 
 ### Breaking Changes

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -11,6 +11,16 @@ class phabricator::config {
     system => true,
   }
 
+  user { $phabricator::daemon_user:
+    ensure     => 'present',
+    comment    => 'Phabricator Daemons',
+    gid        => $phabricator::group,
+    home       => $phabricator::pid_dir,
+    managehome => false,
+    shell      => '/usr/sbin/nologin',
+    system     => true,
+  }
+
   file {
     default:
       owner => 'root',

--- a/manifests/daemons.pp
+++ b/manifests/daemons.pp
@@ -25,16 +25,6 @@
 class phabricator::daemons(
   Optional[String] $daemon,
 ) {
-  user { $phabricator::daemon_user:
-    ensure     => 'present',
-    comment    => 'Phabricator Daemons',
-    gid        => $phabricator::group,
-    home       => $phabricator::pid_dir,
-    managehome => false,
-    shell      => '/usr/sbin/nologin',
-    system     => true,
-  }
-
   # TODO: The `strict_indent` check doesn't seem to work properly here. See
   # https://github.com/relud/puppet-lint-strict_indent-check/issues/11.
   #

--- a/spec/acceptance/daemons_spec.rb
+++ b/spec/acceptance/daemons_spec.rb
@@ -50,18 +50,6 @@ RSpec.describe 'phabricator::daemons' do
     apply_manifest(pp, catch_changes: true)
   end
 
-  context user('phd') do
-    it { is_expected.to exist }
-    it { is_expected.to belong_to_primary_group('phabricator') }
-    it { is_expected.to have_home_directory('/run/phabricator') }
-    it { is_expected.to have_login_shell('/usr/sbin/nologin') }
-  end
-
-  context command('sudo --login --user=phd') do
-    its(:exit_status) { is_expected.not_to be_zero }
-    its(:stdout) { is_expected.to contain('This account is currently not available.') }
-  end
-
   context file('/etc/systemd/system/phd.service') do
     it { is_expected.to be_file }
     it { is_expected.to be_owned_by('root') }

--- a/spec/acceptance/init_spec.rb
+++ b/spec/acceptance/init_spec.rb
@@ -65,6 +65,18 @@ RSpec.describe 'phabricator' do
       it { is_expected.to exist }
     end
 
+    context user('phd') do
+      it { is_expected.to exist }
+      it { is_expected.to belong_to_primary_group('phabricator') }
+      it { is_expected.to have_home_directory('/run/phabricator') }
+      it { is_expected.to have_login_shell('/usr/sbin/nologin') }
+    end
+
+    context command('sudo --login --user=phd') do
+      its(:exit_status) { is_expected.not_to be_zero }
+      its(:stdout) { is_expected.to contain('This account is currently not available.') }
+    end
+
     context file('/var/log/phabricator') do
       it { is_expected.to be_directory }
       it { is_expected.to be_owned_by('root') }

--- a/spec/classes/almanac_spec.rb
+++ b/spec/classes/almanac_spec.rb
@@ -24,8 +24,8 @@ RSpec.describe 'phabricator::almanac', type: :class do
           .with_path('/usr/local/src/phabricator/conf/keys/device.key')
           .with_content(params[:private_key])
           .with_owner('phd')
-          .with_group('root')
-          .with_mode('0400')
+          .with_group('phabricator')
+          .with_mode('0440')
           .that_notifies('Exec[almanac register]')
           .that_requires('Vcsrepo[phabricator]')
       end
@@ -39,7 +39,6 @@ RSpec.describe 'phabricator::almanac', type: :class do
             '--private-key /usr/local/src/phabricator/conf/keys/device.key',
           ].join(' '))
           .with_creates('/usr/local/src/phabricator/conf/keys/device.id')
-          .that_comes_before('Service[phd]')
           .that_requires('Class[php::cli]')
           .that_requires('File[phabricator/conf/local.json]')
           .that_requires('Php::Extension[mysql]')

--- a/spec/classes/config_spec.rb
+++ b/spec/classes/config_spec.rb
@@ -18,6 +18,17 @@ RSpec.describe 'phabricator::config', type: :class do
       end
 
       it do
+        is_expected.to contain_user('phd')
+          .with_ensure('present')
+          .with_comment('Phabricator Daemons')
+          .with_gid('phabricator')
+          .with_home('/run/phabricator')
+          .with_managehome(false)
+          .with_shell('/usr/sbin/nologin')
+          .with_system(true)
+      end
+
+      it do
         is_expected.to contain_file('/var/log/phabricator')
           .with_ensure('directory')
           .with_owner('root')

--- a/spec/classes/daemons_spec.rb
+++ b/spec/classes/daemons_spec.rb
@@ -12,17 +12,6 @@ RSpec.describe 'phabricator::daemons', type: :class do
       it { is_expected.to compile.with_all_deps }
 
       it do
-        is_expected.to contain_user('phd')
-          .with_ensure('present')
-          .with_comment('Phabricator Daemons')
-          .with_gid('phabricator')
-          .with_home('/run/phabricator')
-          .with_managehome(false)
-          .with_shell('/usr/sbin/nologin')
-          .with_system(true)
-      end
-
-      it do
         is_expected.to contain_systemd__unit_file('phd.service')
           .with_ensure('file')
           .with_content(/^Requires=network\.target$/)


### PR DESCRIPTION
Currently the daemon user (`phd`) is created in `Class[phabricator::daemons]`. It seems, however, that this user can be required on hosts that _aren't_ running the actual daemons though. For example, a host that is proxying VCS traffic requires an Almanac device and associated private key, which must be owned by `phd.user`. From the source code:

```
$tmp = new TempFile();
list($err) = exec_manual('chown %s %s', $phd_user, $tmp);
if ($err) {
  throw new PhutilArgumentUsageException(
    pht(
      'Unable to change ownership of an identity file to daemon user '.
      '"%s". Run this command as %s or root.',
      $phd_user,
      $phd_user));
}
```

Furthermore, it seems necessary that the Almanac key is group-readable as well (otherwise the PHP-FPM user would not be able to read this file).

I guess we _could_ try to be a bit more clever and only create the user if `Class[phabricator::almanac]` or `Class[phabricator::daemons]` are defined, but this seems overly complicated. Practically speaking, I think it's at least somewhat reasonable to just _always_ create the daemon user, even if it is possibly unnecessary for the given node.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/joshuaspence/puppet-phabricator/11)
<!-- Reviewable:end -->
