### PR TITLE
Add support for installing additional fonts

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -4,6 +4,7 @@ fixtures:
     apt: 'puppetlabs/apt'
     archive: 'puppet/archive'
     concat: 'puppetlabs/concat'
+    debconf: 'stm/debconf'
     git: 'puppetlabs/git'
     inifile: 'puppetlabs/inifile'
     logrotate: 'puppet/logrotate'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - The [`ws`](https://www.npmjs.com/package/ws) NPM package is no longer pinned
   to version `2.3.1`. See [T12755: Aphlict doesn't work with the latest version
   of `ws`](https://secure.phabricator.com/T12755).
+- Added an `$install_fonts` flag to install optional fonts.
 
 ## 0.5.6
 

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -8,6 +8,7 @@ phabricator::config_hash: {}
 phabricator::daemon_user: 'phd'
 phabricator::group: 'phabricator'
 phabricator::install_dir: '/usr/local/src'
+phabricator::install_fonts: false
 phabricator::libphutil_revision: 'stable'
 phabricator::logs_dir: '/var/log/phabricator'
 phabricator::manage_diffusion: false

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -21,6 +21,7 @@
 # @param config_hash Phabricator configuration. See
 #   {https://secure.phabricator.com/book/phabricator/article/advanced_configuration/
 #   Configuration User Guide: Advanced Configuration}.
+# @param install_fonts Whether to install additional fonts.
 # @param manage_diffusion Whether to configure the host in order to be able to
 #   serve (either directly or by proxying to another host in the cluster). See
 #   {https://secure.phabricator.com/book/phabricator/article/diffusion_hosting/
@@ -48,6 +49,7 @@ class phabricator(
   Phabricator::Revision $libphutil_revision = 'stable',
   Phabricator::Revision $phabricator_revision = 'stable',
   Hash[String, Data] $config_hash = {},
+  Boolean $install_fonts = false,
   Boolean $manage_diffusion = false,
   Boolean $storage_upgrade = false,
   Optional[String] $storage_upgrade_user = undef,

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -57,4 +57,28 @@ class phabricator::install {
     ],
     subscribe   => Vcsrepo['libphutil'],
   }
+
+  if $phabricator::install_fonts {
+    debconf { 'msttcorefonts/accepted-mscorefonts-eula':
+      ensure  => 'present',
+      package => 'ttf-mscorefonts-installer',
+      type    => 'select',
+      value   => bool2str(true),
+      before  => Package['ttf-mscorefonts-installer'],
+    }
+
+    package { 'ttf-mscorefonts-installer':
+      ensure  => 'latest',
+    }
+
+    $font_file_ensure = 'link'
+  } else {
+    $font_file_ensure = 'absent'
+  }
+
+  file { "${phabricator::install_dir}/phabricator/resources/font/impact.ttf":
+    ensure  => $font_file_ensure,
+    target  => '/usr/share/fonts/truetype/msttcorefonts/Impact.ttf',
+    require => Vcsrepo['phabricator'],
+  }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -38,6 +38,10 @@
       "version_requirement": ">= 2.9.0 < 4.0.0"
     },
     {
+      "name": "stm/debconf",
+      "version_requirement": "2.x"
+    },
+    {
       "name": "puppetlabs/stdlib",
       "version_requirement": ">= 4.2.0 < 5.0.0"
     },

--- a/spec/acceptance/init_spec.rb
+++ b/spec/acceptance/init_spec.rb
@@ -31,6 +31,7 @@ RSpec.describe 'phabricator' do
         'mysql.pass' => 'root',
       },
 
+      install_fonts            => true,
       manage_diffusion         => true,
       storage_upgrade          => true,
       storage_upgrade_user     => 'root',
@@ -250,6 +251,14 @@ RSpec.describe 'phabricator' do
 
     context command('/usr/local/src/phabricator/bin/config list') do
       its(:exit_status) { is_expected.to be_zero }
+    end
+
+    context package('ttf-mscorefonts-installer') do
+      it { is_expected.to be_installed }
+    end
+
+    context file('/usr/local/src/phabricator/resources/font/impact.ttf') do
+      it { is_expected.to be_symlink }
     end
   end
 end

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -331,6 +331,49 @@ RSpec.describe 'phabricator', type: :class do
 
           it { is_expected.to contain_vcsrepo('phabricator').with_revision(revision) }
         end
+
+        context 'when $install_fonts is disabled' do
+          let(:params) do
+            {
+              install_fonts: false,
+            }
+          end
+
+          it do
+            is_expected.to contain_file('/usr/local/src/phabricator/resources/font/impact.ttf')
+              .with_ensure('absent')
+              .that_requires('Vcsrepo[phabricator]')
+          end
+        end
+
+        context 'when $install_fonts is enabled' do
+          let(:params) do
+            {
+              install_fonts: true,
+            }
+          end
+
+          it do
+            is_expected.to contain_debconf('msttcorefonts/accepted-mscorefonts-eula')
+              .with_ensure('present')
+              .with_package('ttf-mscorefonts-installer')
+              .with_type('select')
+              .with_value('true')
+              .that_comes_before('Package[ttf-mscorefonts-installer]')
+          end
+
+          it do
+            is_expected.to contain_package('ttf-mscorefonts-installer')
+              .with_ensure('latest')
+          end
+
+          it do
+            is_expected.to contain_file('/usr/local/src/phabricator/resources/font/impact.ttf')
+              .with_ensure('link')
+              .with_target('/usr/share/fonts/truetype/msttcorefonts/Impact.ttf')
+              .that_requires('Vcsrepo[phabricator]')
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
Add support for installing additional fonts, specifically [Impact](https://en.wikipedia.org/wiki/Impact_(typeface)). From the [Remarkup documentation](https://secure.phabricator.com/book/phabricator/article/remarkup/#memes):

> By default, the font used to create the text for the meme is `tuffy.ttf`. For the more authentic feel of `impact.ttf`, you simply have to place the Impact TrueType font in the Phabricator subfolder `/resources/font/`. If Remarkup detects the presence of `impact.ttf`, it will automatically use it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/joshuaspence/puppet-phabricator/15)
<!-- Reviewable:end -->
