### PR TITLE
Use `systemd-tmpfiles` to manage PID directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## 0.5.11 (unreleased)
 
+### Features
+
+- Use `systemd-tmpfiles` for managing the `/run/phabricator` directory.
+  This should allow daemons to start correctly even if `/run/phabricator` 
+  does not exist.
+
 ### Bug fixes
 
 - Ensure that PHP is installed before starting Aphlict.

--- a/manifests/aphlict.pp
+++ b/manifests/aphlict.pp
@@ -89,6 +89,11 @@ class phabricator::aphlict(
   }
   # lint:endignore
 
+  systemd::tmpfile { 'aphlict.conf':
+    ensure  => 'file',
+    content => "d ${phabricator::pid_dir} 0775 ${phabricator::daemon_user} ${phabricator::group}",
+  }
+
   # TODO: Should we also specify `hasrestart => true`? According to the
   # documentation the default value is `false`, although I am somewhat
   # surprised by this.
@@ -98,8 +103,8 @@ class phabricator::aphlict(
     require   => [
       Class['php::cli'],
       Exec['systemctl-daemon-reload'],
+      Exec['systemd-tmpfiles'],
       File[$phabricator::logs_dir],
-      File[$phabricator::pid_dir],
       Group[$phabricator::group],
       User[$user],
       Vcsrepo['arcanist'],

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -47,10 +47,6 @@ class phabricator::config {
       ensure => 'directory',
       mode   => '0775';
 
-    $phabricator::pid_dir:
-      ensure => 'directory',
-      mode   => '0775';
-
     $phabricator::repo_dir:
       ensure => 'directory',
       owner  => $phabricator::daemon_user,

--- a/manifests/daemons.pp
+++ b/manifests/daemons.pp
@@ -43,6 +43,11 @@ class phabricator::daemons(
   }
   # lint:endignore
 
+  systemd::tmpfile { 'phd.conf':
+    ensure  => 'file',
+    content => "d ${phabricator::pid_dir} 0775 ${phabricator::daemon_user} ${phabricator::group}",
+  }
+
   # TODO: Should we also specify `hasrestart => true`? According to the
   # documentation the default value is `false`, although I am somewhat
   # surprised by this.
@@ -51,8 +56,8 @@ class phabricator::daemons(
     enable    => true,
     require   => [
       Exec['systemctl-daemon-reload'],
+      Exec['systemd-tmpfiles'],
       File[$phabricator::logs_dir],
-      File[$phabricator::pid_dir],
       Group[$phabricator::group],
       User[$phabricator::daemon_user],
     ],

--- a/spec/acceptance/init_spec.rb
+++ b/spec/acceptance/init_spec.rb
@@ -97,13 +97,6 @@ RSpec.describe 'phabricator' do
       it { is_expected.to be_mode(775) }
     end
 
-    context file('/run/phabricator') do
-      it { is_expected.to be_directory }
-      it { is_expected.to be_owned_by('root') }
-      it { is_expected.to be_grouped_into('phabricator') }
-      it { is_expected.to be_mode(775) }
-    end
-
     context file('/var/repo') do
       it { is_expected.to be_directory }
       it { is_expected.to be_owned_by('phd') }
@@ -119,16 +112,16 @@ RSpec.describe 'phabricator' do
 
       its(:content_as_json) do
         is_expected.to eq(
-          'diffusion.ssh-user' => 'diffusion',
-          'environment.append-paths' => ['/usr/lib/git-core'],
-          'log.access.path' => '/var/log/phabricator/access.log',
-          'log.ssh.path' => '/var/log/phabricator/ssh.log',
-          'mysql.host' => 'localhost',
-          'mysql.user' => 'root',
-          'mysql.pass' => 'root',
-          'phd.log-directory' => '/var/log/phabricator',
-          'phd.pid-directory' => '/run/phabricator',
-          'phd.user' => 'phd',
+          'diffusion.ssh-user'            => 'diffusion',
+          'environment.append-paths'      => ['/usr/lib/git-core'],
+          'log.access.path'               => '/var/log/phabricator/access.log',
+          'log.ssh.path'                  => '/var/log/phabricator/ssh.log',
+          'mysql.host'                    => 'localhost',
+          'mysql.user'                    => 'root',
+          'mysql.pass'                    => 'root',
+          'phd.log-directory'             => '/var/log/phabricator',
+          'phd.pid-directory'             => '/run/phabricator',
+          'phd.user'                      => 'phd',
           'repository.default-local-path' => '/var/repo',
         )
       end
@@ -139,17 +132,17 @@ RSpec.describe 'phabricator' do
         is_expected.to include(
           'config' => [
             {
-              'key' => 'mysql.host',
-              'source' => 'local',
-              'value' => 'localhost',
-              'status' => 'set',
+              'key'       => 'mysql.host',
+              'source'    => 'local',
+              'value'     => 'localhost',
+              'status'    => 'set',
               'errorInfo' => nil,
             },
             {
-              'key' => 'mysql.host',
-              'source' => 'database',
-              'value' => nil,
-              'status' => 'unset',
+              'key'       => 'mysql.host',
+              'source'    => 'database',
+              'value'     => nil,
+              'status'    => 'unset',
               'errorInfo' => nil,
             },
           ],

--- a/spec/classes/aphlict_spec.rb
+++ b/spec/classes/aphlict_spec.rb
@@ -84,13 +84,19 @@ RSpec.describe 'phabricator::aphlict', type: :class do
       end
 
       it do
+        is_expected.to contain_systemd__tmpfile('aphlict.conf')
+          .with_ensure('file')
+          .with_content('d /run/phabricator 0775 phd phabricator')
+      end
+
+      it do
         is_expected.to contain_service('aphlict')
           .with_ensure('running')
           .with_enable(true)
           .that_requires('Class[php::cli]')
           .that_requires('Exec[systemctl-daemon-reload]')
+          .that_requires('Exec[systemd-tmpfiles]')
           .that_requires('File[/var/log/phabricator]')
-          .that_requires('File[/run/phabricator]')
           .that_requires('Group[phabricator]')
           .that_requires('User[aphlict]')
           .that_requires('Vcsrepo[arcanist]')

--- a/spec/classes/daemons_spec.rb
+++ b/spec/classes/daemons_spec.rb
@@ -27,12 +27,18 @@ RSpec.describe 'phabricator::daemons', type: :class do
       end
 
       it do
+        is_expected.to contain_systemd__tmpfile('phd.conf')
+          .with_ensure('file')
+          .with_content('d /run/phabricator 0775 phd phabricator')
+      end
+
+      it do
         is_expected.to contain_service('phd')
           .with_ensure('running')
           .with_enable(true)
           .that_requires('Exec[systemctl-daemon-reload]')
+          .that_requires('Exec[systemd-tmpfiles]')
           .that_requires('File[/var/log/phabricator]')
-          .that_requires('File[/run/phabricator]')
           .that_requires('Group[phabricator]')
           .that_requires('User[phd]')
           .that_subscribes_to('Class[php::cli]')

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -47,14 +47,6 @@ RSpec.describe 'phabricator', type: :class do
         end
 
         it do
-          is_expected.to contain_file('/run/phabricator')
-            .with_ensure('directory')
-            .with_owner('root')
-            .with_group('phabricator')
-            .with_mode('0775')
-        end
-
-        it do
           is_expected.to contain_file('/var/repo')
             .with_ensure('directory')
             .with_owner('phd')


### PR DESCRIPTION
This should allow the daemons to be started without `/run/phabricator` existing (as is the case on a reboot when `/run` is mounted on a `tmpfs`).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/joshuaspence/puppet-phabricator/16)
<!-- Reviewable:end -->
