### PR TITLE
Use `RuntimeDirectory` to manage `/run/phabricator`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@
 
 - Ensure that PHP is installed before starting Aphlict.
 
+### Features
+
+- Set `RuntimeDirectory` for daemons so that `/run/phabricator` is created
+  automatically. This should mean that daemons survive a system reboot.
+
 ## 0.5.10
 
 ### Bug fixes

--- a/manifests/aphlict.pp
+++ b/manifests/aphlict.pp
@@ -68,9 +68,10 @@ class phabricator::aphlict(
   systemd::unit_file { 'aphlict.service':
     ensure  => 'file',
     content => epp('phabricator/aphlict.systemd.epp', {
-      command => "${phabricator::install_dir}/phabricator/bin/aphlict",
-      user    => $user,
-      group   => $phabricator::group,
+      command           => "${phabricator::install_dir}/phabricator/bin/aphlict",
+      user              => $user,
+      group             => $phabricator::group,
+      runtime_directory => $phabricator::runtime_directory,
     }),
     notify  => Service['aphlict'],
   }
@@ -86,7 +87,6 @@ class phabricator::aphlict(
       Class['php::cli'],
       Exec['systemctl-daemon-reload'],
       File[$phabricator::logs_dir],
-      File[$phabricator::pid_dir],
       Group[$phabricator::group],
       User[$user],
       Vcsrepo['arcanist'],

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -47,10 +47,6 @@ class phabricator::config {
       ensure => 'directory',
       mode   => '0775';
 
-    $phabricator::pid_dir:
-      ensure => 'directory',
-      mode   => '0775';
-
     $phabricator::repo_dir:
       ensure => 'directory',
       owner  => $phabricator::daemon_user,

--- a/manifests/daemons.pp
+++ b/manifests/daemons.pp
@@ -32,10 +32,11 @@ class phabricator::daemons(
   systemd::unit_file { 'phd.service':
     ensure  => 'file',
     content => epp('phabricator/daemons.systemd.epp', {
-      command => "${phabricator::install_dir}/phabricator/bin/phd",
-      daemon  => $daemon,
-      user    => $phabricator::daemon_user,
-      group   => $phabricator::group,
+      command           => "${phabricator::install_dir}/phabricator/bin/phd",
+      daemon            => $daemon,
+      user              => $phabricator::daemon_user,
+      group             => $phabricator::group,
+      runtime_directory => $phabricator::runtime_directory,
     }),
     notify  => Service['phd'],
   }
@@ -50,7 +51,6 @@ class phabricator::daemons(
     require   => [
       Exec['systemctl-daemon-reload'],
       File[$phabricator::logs_dir],
-      File[$phabricator::pid_dir],
       Group[$phabricator::group],
       User[$phabricator::daemon_user],
     ],

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -66,6 +66,12 @@ class phabricator(
     assert_type(String, $storage_upgrade_password)
   }
 
+  if $pid_dir =~ /^\/run\// {
+    $runtime_directory = regsubst($pid_dir, /^\/run\//, '')
+  } else {
+    fail('$pid_dir must be a descendent of /run.')
+  }
+
   $config = merge(
     $config_hash,
     {

--- a/spec/acceptance/init_spec.rb
+++ b/spec/acceptance/init_spec.rb
@@ -97,13 +97,6 @@ RSpec.describe 'phabricator' do
       it { is_expected.to be_mode(775) }
     end
 
-    context file('/run/phabricator') do
-      it { is_expected.to be_directory }
-      it { is_expected.to be_owned_by('root') }
-      it { is_expected.to be_grouped_into('phabricator') }
-      it { is_expected.to be_mode(775) }
-    end
-
     context file('/var/repo') do
       it { is_expected.to be_directory }
       it { is_expected.to be_owned_by('phd') }

--- a/spec/classes/aphlict_spec.rb
+++ b/spec/classes/aphlict_spec.rb
@@ -79,6 +79,7 @@ RSpec.describe 'phabricator::aphlict', type: :class do
           .with_content(%r{^ExecStop=/usr/local/src/phabricator/bin/aphlict stop$})
           .with_content(/^User=aphlict$/)
           .with_content(/^Group=phabricator$/)
+          .with_content(/^RuntimeDirectory=phabricator$/)
           .with_content(/^WantedBy=multi-user\.target$/)
           .that_notifies('Service[aphlict]')
       end
@@ -90,7 +91,6 @@ RSpec.describe 'phabricator::aphlict', type: :class do
           .that_requires('Class[php::cli]')
           .that_requires('Exec[systemctl-daemon-reload]')
           .that_requires('File[/var/log/phabricator]')
-          .that_requires('File[/run/phabricator]')
           .that_requires('Group[phabricator]')
           .that_requires('User[aphlict]')
           .that_requires('Vcsrepo[arcanist]')

--- a/spec/classes/daemons_spec.rb
+++ b/spec/classes/daemons_spec.rb
@@ -22,6 +22,7 @@ RSpec.describe 'phabricator::daemons', type: :class do
           .with_content(%r{^ExecStop=/usr/local/src/phabricator/bin/phd stop$})
           .with_content(/^User=phd$/)
           .with_content(/^Group=phabricator$/)
+          .with_content(/^RuntimeDirectory=phabricator$/)
           .with_content(/^WantedBy=multi-user\.target$/)
           .that_notifies('Service[phd]')
       end
@@ -32,7 +33,6 @@ RSpec.describe 'phabricator::daemons', type: :class do
           .with_enable(true)
           .that_requires('Exec[systemctl-daemon-reload]')
           .that_requires('File[/var/log/phabricator]')
-          .that_requires('File[/run/phabricator]')
           .that_requires('Group[phabricator]')
           .that_requires('User[phd]')
           .that_subscribes_to('Class[php::cli]')

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -47,14 +47,6 @@ RSpec.describe 'phabricator', type: :class do
         end
 
         it do
-          is_expected.to contain_file('/run/phabricator')
-            .with_ensure('directory')
-            .with_owner('root')
-            .with_group('phabricator')
-            .with_mode('0775')
-        end
-
-        it do
           is_expected.to contain_file('/var/repo')
             .with_ensure('directory')
             .with_owner('phd')
@@ -196,6 +188,19 @@ RSpec.describe 'phabricator', type: :class do
           end
         end
 
+        context 'with invalid $pid_dir' do
+          let(:params) do
+            {
+              pid_dir: '/derp',
+            }
+          end
+
+          it do
+            is_expected.to compile
+              .and_raise_error(%r{\$pid_dir must be a descendent of /run})
+          end
+        end
+
         describe 'File[phabricator/conf/local.json]' do
           subject do
             resource = catalogue.resource('file', 'phabricator/conf/local.json')
@@ -234,16 +239,16 @@ RSpec.describe 'phabricator', type: :class do
 
             it do
               is_expected.to eq(
-                'diffusion.ssh-user' => 'diffusion',
-                'environment.append-paths' => ['/usr/lib/git-core'],
-                'log.access.path' => '/var/log/phabricator/access.log',
-                'log.ssh.path' => '/var/log/phabricator/ssh.log',
-                'mysql.host' => config_hash['mysql.host'],
-                'mysql.user' => config_hash['mysql.user'],
-                'mysql.pass' => config_hash['mysql.pass'],
-                'phd.log-directory' => '/var/log/phabricator',
-                'phd.pid-directory' => '/run/phabricator',
-                'phd.user' => 'phd',
+                'diffusion.ssh-user'            => 'diffusion',
+                'environment.append-paths'      => ['/usr/lib/git-core'],
+                'log.access.path'               => '/var/log/phabricator/access.log',
+                'log.ssh.path'                  => '/var/log/phabricator/ssh.log',
+                'mysql.host'                    => config_hash['mysql.host'],
+                'mysql.user'                    => config_hash['mysql.user'],
+                'mysql.pass'                    => config_hash['mysql.pass'],
+                'phd.log-directory'             => '/var/log/phabricator',
+                'phd.pid-directory'             => '/run/phabricator',
+                'phd.user'                      => 'phd',
                 'repository.default-local-path' => '/var/repo',
               )
             end

--- a/templates/aphlict.systemd.epp
+++ b/templates/aphlict.systemd.epp
@@ -1,4 +1,9 @@
-<%- | Stdlib::Unixpath $command, String $user, String $group | -%>
+<%- |
+  Stdlib::Unixpath $command,
+  String $user,
+  String $group,
+  String $runtime_directory,
+| -%>
 [Unit]
 Description=Aphlict
 Documentation=https://secure.phabricator.com/book/phabricator/article/notifications/
@@ -13,6 +18,7 @@ ExecStop=<%= $command %> stop
 Restart=on-failure
 User=<%= $user %>
 Group=<%= $group %>
+RuntimeDirectory=<%= $runtime_directory %>
 
 [Install]
 WantedBy=multi-user.target

--- a/templates/daemons.systemd.epp
+++ b/templates/daemons.systemd.epp
@@ -3,6 +3,7 @@
   Optional[String] $daemon,
   String $user,
   String $group,
+  String $runtime_directory,
 | -%>
 [Unit]
 Description=Phabricator Daemons
@@ -25,6 +26,7 @@ ExecReload=<%= $command %> restart
 ExecStop=<%= $command %> stop
 User=<%= $user %>
 Group=<%= $group %>
+RuntimeDirectory=<%= $runtime_directory %>
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
This should allow the daemons to be started without `/run/phabricator` existing (as is the case on a reboot when `/run` is mounted on a `tmpfs`).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/joshuaspence/puppet-phabricator/17)
<!-- Reviewable:end -->
